### PR TITLE
Scope snippets to a ludwig-yaml language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [0.3.0]
 
+### Breaking
+
+- Snippets are now scoped to a new `ludwig-yaml` language instead of every
+  `.yaml` file. With 644 snippets, contributing them to YAML at large would put
+  Ludwig completions into every Compose, Kubernetes and CI file you open.
+  Files are recognised automatically when named `*.ludwig.yaml`, `*.ludwig.yml`,
+  `ludwig.yaml`, `ludwig.yml`, `ludwig_config.yaml` or `ludwig_config.yml`.
+  For any other name, add a `files.associations` entry — see the README.
+  Highlighting is unchanged; the language reuses the built-in YAML grammar.
+
 Rebuilt the library against **Ludwig 0.17.8**. Snippets are now generated from
 Ludwig's own config schema instead of being written by hand, growing the library
 from 43 to 644 snippets and covering every section of a Ludwig config.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ what Ludwig actually accepts.
 
 ## Quick start
 
-Open a `.yaml` file and type a prefix:
+Name your config so the extension recognises it — `model.ludwig.yaml`, or just
+`ludwig.yaml` — then type a prefix:
 
 | Prefix | What you get |
 | ------ | ------------ |
@@ -24,6 +25,45 @@ Open a `.yaml` file and type a prefix:
 | `llm-adapter-lora` | A LoRA adapter block |
 
 Every prefix is listed in **[SNIPPETS.md](SNIPPETS.md)**.
+
+## Which files the snippets appear in
+
+The snippets are scoped to a `ludwig-yaml` language rather than to YAML at large,
+so a Compose or Kubernetes file does not get 644 Ludwig completions it can never
+use. Files pick that language up automatically when they are named:
+
+- `*.ludwig.yaml` / `*.ludwig.yml`
+- `ludwig.yaml` / `ludwig.yml` / `ludwig_config.yaml` / `ludwig_config.yml`
+
+Highlighting, folding and comments behave exactly as in YAML — the language
+reuses the built-in YAML grammar.
+
+If your configs are named something else (`config.yaml`, `experiments/*.yaml`),
+map them yourself:
+
+```jsonc
+// .vscode/settings.json
+{
+  "files.associations": {
+    "config.yaml": "ludwig-yaml",
+    "experiments/*.yaml": "ludwig-yaml"
+  }
+}
+```
+
+You can also switch a single open file with **Change Language Mode**
+(<kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>K</kbd> <kbd>M</kbd>) → *Ludwig YAML*.
+
+> **Changed in 0.3.0.** Up to 0.2.1 the snippets were contributed to every
+> `.yaml` file. If you relied on that, add a `files.associations` entry as above.
+
+## Ludwig version
+
+Generated from **Ludwig 0.17.8**. Parameter names, defaults and allowed values
+match that release; the exact version is recorded in `package.json` under
+`ludwig.generatedFrom`. On substantially older Ludwig (0.10 and earlier) some
+parameters will not exist — and Ludwig ignores keys it does not recognise rather
+than reporting them, so the setting would be silently dropped.
 
 ## How the prefixes are built
 
@@ -94,7 +134,8 @@ schema rather than written by hand.
 
 For live validation and hover documentation while you type, pair this extension
 with the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
-and point it at a schema exported from your Ludwig install:
+and point it at a schema exported from your own Ludwig install (Ludwig's published
+schema URLs are not currently reachable):
 
 ```bash
 ludwig export_schema --model-type ecd -o ludwig-schema.json

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,30 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "folding": {
+    "offSide": true
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*[-\\w'\"\\[\\]]+\\s*:\\s*$",
+      "action": { "indent": "indent" }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ludwig-snippets",
   "displayName": "Ludwig Snippets",
-  "description": "Snippets for every section of a Ludwig config: features, encoders, decoders, combiners, losses, preprocessing, trainer, hyperopt and LLM fine-tuning. Generated from Ludwig's own schema.",
+  "description": "644 snippets for every section of a Ludwig config — features, encoders, decoders, combiners, losses, preprocessing, trainer, hyperopt and LLM fine-tuning. Generated from Ludwig 0.17's own schema, so parameter names and defaults match what Ludwig actually accepts. Activates on .ludwig.yaml files.",
   "repository": {
     "type": "git",
     "url": "https://github.com/mhabedank/ludwig-snippets"
@@ -43,149 +43,176 @@
     "yaml": "^2.8.1"
   },
   "contributes": {
+    "languages": [
+      {
+        "id": "ludwig-yaml",
+        "aliases": [
+          "Ludwig YAML",
+          "ludwig-yaml"
+        ],
+        "extensions": [
+          ".ludwig.yaml",
+          ".ludwig.yml"
+        ],
+        "filenames": [
+          "ludwig.yaml",
+          "ludwig.yml",
+          "ludwig_config.yaml",
+          "ludwig_config.yml"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "ludwig-yaml",
+        "scopeName": "source.ludwig-yaml",
+        "path": "./syntaxes/ludwig-yaml.tmLanguage.json"
+      }
+    ],
     "snippets": [
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/combiners.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/config.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/anomaly.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/binary.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/category.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/category_distribution.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/image.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/llm-category.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/llm-text.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/number.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/sequence.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/set.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/text.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/timeseries.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/decoders/vector.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/defaults.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/audio.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/bag.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/binary.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/category.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/date.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/h3.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/image.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/llm-text.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/number.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/sequence.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/set.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/text.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/timeseries.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/encoders/vector.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/features.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/hyperopt.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/llm.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/losses.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/preprocessing.code-snippets"
       },
       {
-        "language": "yaml",
+        "language": "ludwig-yaml",
         "path": "./snippets/trainer.code-snippets"
       }
     ]

--- a/syntaxes/ludwig-yaml.tmLanguage.json
+++ b/syntaxes/ludwig-yaml.tmLanguage.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Ludwig YAML",
+  "scopeName": "source.ludwig-yaml",
+  "comment": "Ludwig configs are plain YAML. This grammar exists only so the ludwig-yaml language can carry its own snippet scope; all highlighting is delegated to the built-in YAML grammar.",
+  "patterns": [
+    {
+      "include": "source.yaml"
+    }
+  ]
+}

--- a/tools/generate-snippets.mjs
+++ b/tools/generate-snippets.mjs
@@ -820,10 +820,17 @@ function renderReference() {
   return `${out.join("\n")}\n`;
 }
 
+/**
+ * Snippets are scoped to the `ludwig-yaml` language rather than `yaml`, so a
+ * Compose or k8s file does not get 644 Ludwig completions it can never use.
+ * See `contributes.languages` in package.json for how a file gets that id.
+ */
+const SNIPPET_LANGUAGE = "ludwig-yaml";
+
 function packageContribution() {
   return [...files.keys()]
     .sort()
-    .map((file) => ({ language: "yaml", path: `./snippets/${file}` }));
+    .map((file) => ({ language: SNIPPET_LANGUAGE, path: `./snippets/${file}` }));
 }
 
 function main() {


### PR DESCRIPTION
Follow-up to #2, which took the library from 43 to 644 snippets. At that size, contributing them to every `.yaml` file puts Ludwig completions into every Compose, Kubernetes and CI file you open. This defines a `ludwig-yaml` language and scopes the snippets to it.

## How files get the language

Automatically, when named:

- `*.ludwig.yaml` / `*.ludwig.yml`
- `ludwig.yaml` / `ludwig.yml` / `ludwig_config.yaml` / `ludwig_config.yml`

Anything else needs a `files.associations` entry, or a one-off **Change Language Mode**. Both are documented in the README.

Highlighting, folding and comments are unchanged: the language ships a grammar that delegates to the built-in `source.yaml`, plus a YAML-shaped `language-configuration.json`.

## Breaking

This is breaking for anyone on 0.2.1, who had the snippets in every YAML file. Called out at the top of the changelog and in a `Changed in 0.3.0` note in the README. 0.3.0 has not been published yet, so no released version regresses.

## Marketplace copy

`package.json` `description` now states the snippet count, that the library is generated from Ludwig 0.17's own schema, and which files it activates on. The README gains a **Ludwig version** section noting that the snippets target 0.17.8 and that older Ludwig will silently drop parameters it does not know.

## Verification

- `npm run generate -- --check` — generated output matches the committed files
- `npm test` — 644 snippets, 668 unique prefixes, all contributed under `ludwig-yaml`
- `vsce package` / `vsce ls` — 69 KB, `language-configuration.json` and `syntaxes/ludwig-yaml.tmLanguage.json` both included

Not verified in a running editor: that the grammar's `include: source.yaml` resolves against the built-in YAML extension. It is the standard cross-extension include and the manifest is well-formed, but worth a quick F5 in the Extension Development Host before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)